### PR TITLE
Added required gems to make the api server work

### DIFF
--- a/dispatchr-ruby/Gemfile
+++ b/dispatchr-ruby/Gemfile
@@ -9,6 +9,7 @@ gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.0'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
+gem 'active_model_serializers'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 3.0'
 # Use ActiveModel has_secure_password
@@ -18,7 +19,7 @@ gem 'jbuilder', '~> 2.5'
 # gem 'capistrano-rails', group: :development
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/dispatchr-ruby/app/controllers/application_controller.rb
+++ b/dispatchr-ruby/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::API
+    include ActionController::Serialization
 end


### PR DESCRIPTION
Added the gems to make the api server probably work with JSON and Rails 5.

> In it’s current state our app will just spit out a JSON representation of every column in the database so we need a way to control what data gets served through the API.
> 
> Normally we would use a front end templating engine such as jbuilder for this purpose, but since we’re not using views in our super streamlined API app, that’s not going to be an option.
> 
> Fortunately AMS (Active Model Serializers) is here to save the day. AMS provides a clean layer between the model and the controller that lets us to call to_json or as_json on the ActiveRecord object or collection as normal, while outputing our desired API format.